### PR TITLE
[fix] Changed opacity values to decimal

### DIFF
--- a/client/src/components/Background/Background.css
+++ b/client/src/components/Background/Background.css
@@ -20,11 +20,11 @@
 
 .whiteOverlay {
     position: absolute;
-    opacity: 40%;
+    opacity: 0.4;
     background-color: white;
     width: 100%;
     height: 200vh;
-    animation: fadein 10s ease-in;
+    animation: fadein 3s ease-in;
 }
 
 .level1 {
@@ -84,6 +84,6 @@
         opacity: 0;
     }
     100% {
-        opacity: 40%;
+        opacity: 0.4;
     }
 }


### PR DESCRIPTION
Bug was upstream ([CRA Issue](https://github.com/facebook/create-react-app/issues/7980)) during build process. Workaround is to use decimal instead of percentages.