### PR TITLE
Prevent multiple turn progressions at once

### DIFF
--- a/client/src/atoms/game.ts
+++ b/client/src/atoms/game.ts
@@ -23,7 +23,7 @@ export const TurnTrackerAtom = atom<{
         numPlayers: [],
     },
     effects_UNSTABLE: [
-        EmitEffect(GameEvents.SET_TURN),
+        // EmitEffect(GameEvents.SET_TURN),
         // LoggerEffect('Turn tracker'),
     ],
 });


### PR DESCRIPTION
Turn progression step is computed by each player. Since they also communicate realtime, it becomes a race condition where we can possibly progress by more than one step. Fixed by removing the real-time syncing code. Fixes #8 